### PR TITLE
Remove unnecessary css links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,6 @@
     <meta name="twitter:creator" content="@{{ site.twitter_username }}">
     <meta name="twitter:domain" content="{{ site.url }}">
     <meta property="twitter:image" content="{% if page.image %}{{ page.image }}{% else %}{{ site.default_img }}{% endif %}">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inconsolata|Lora|Space+Mono:700">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css">
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | prepend: site.baseurl }}">


### PR DESCRIPTION
Signed-off by: Marc Anthony Reyes (<marcreyesmedia@gmail.com>)

 Remove unnecessary css links in head meta