### PR TITLE
Remove unnecessary imports

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -2,7 +2,6 @@
 ---
 
 @import url('fonts.css');
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:500');
 
 @import
   'base',


### PR DESCRIPTION
Signed-off by: Marc Anthony Reyes (<marcreyesmedia@gmail.com>)

Remove unnecessary css imports in the main sass file